### PR TITLE
Replace manual tests with pytest in GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,33 +31,19 @@ jobs:
     with:
       package-path: .
       python-version: ${{ inputs.python-version || '3.x' }}
-  test-cli:
+  unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ inputs.python-version || '3.x' }}
-      - name: Install packages
+      - name: Install dependencies
         run: |
-          pip install -U --no-cache-dir .
-      - name: Test the class
-        shell: python {0}
+          pip install -U --no-cache-dir pip uv
+          uv sync
+      - name: Run unit tests
         run: |
-          from shoper import ShellOperator
-          sh = ShellOperator()
-          sh.run('ls -l')
-          sh.run(
-              args=[
-                  'echo ${RANDOM} | tee random0.txt',
-                  'echo ${RANDOM} | tee random1.txt',
-                  'echo ${RANDOM} | tee random2.txt'
-              ],
-              output_files_or_dirs=['random0.txt', 'random1.txt', 'random2.txt']
-          )
-          sh.run(
-              args='sort random[012].txt | tee sorted.txt',
-              input_files_or_dirs=['random0.txt', 'random1.txt', 'random2.txt'],
-              output_files_or_dirs='sorted.txt'
-          )
+          uv run pytest


### PR DESCRIPTION
## Summary
- Replaced inline Python test scripts with pytest in the test workflow
- Renamed job from `test-cli` to `unit-test` for clarity
- Updated dependency installation to use uv sync for consistency

## Test plan
- [ ] GitHub Actions workflow runs successfully
- [ ] pytest executes all test files
- [ ] All existing functionality is preserved

🤖 Generated with [Claude Code](https://claude.ai/code)