### PR TITLE
Update .github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,6 @@ on:
           - release
         description: Choose the workflow to run
         default: lint-and-test
-      python-version:
-        required: false
-        type: string
-        description: Python version to use
-        default: 3.x
 defaults:
   run:
     shell: bash -euo pipefail {0}
@@ -35,24 +30,14 @@ jobs:
     uses: dceoy/gh-actions-for-devops/.github/workflows/python-package-lint-and-scan.yml@main
     with:
       package-path: .
-      python-version: ${{ inputs.python-version || '3.x' }}
   python-test:
     if: >
       github.event_name == 'push'
       || github.event_name == 'pull_request'
       || (github.event_name == 'workflow_dispatch' && inputs.workflow == 'lint-and-test')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
-      - name: Set up uv
-        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3
-      - name: Install the package
-        run: >
-          uv sync
-      - name: Run unit tests with pytest
-        run: >
-          uv run pytest
+    uses: dceoy/gh-actions-for-devops/.github/workflows/python-package-test.yml@main
+    with:
+      package-path: .
   dependabot-auto-merge:
     if: >
       github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
@@ -80,7 +65,6 @@ jobs:
     with:
       package-path: .
       create-releases: ${{ github.event_name == 'workflow_dispatch' && inputs.workflow == 'release' }}
-      python-version: ${{ inputs.python-version || '3.x' }}
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request refactors the CI workflow configuration in `.github/workflows/ci.yml` to simplify Python version management and streamline job definitions. The main change is the removal of the `python-version` input parameter, resulting in more standardized and maintainable workflow steps.

Workflow configuration simplification:

* Removed the `python-version` input parameter from the workflow, eliminating custom Python version selection and defaulting to the configuration in the reusable workflows.

Job definition updates:

* Updated the `python-lint-and-scan` and `python-release` jobs to remove the explicit passing of the `python-version` input, relying on the reusable workflows' default settings. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL38-R40) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL83)
* Replaced the manually defined steps in the `python-test` job with a call to a reusable workflow (`python-package-test.yml`), reducing boilerplate and improving consistency.