### PR TITLE
Split release workflow from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,5 +70,7 @@ jobs:
       contents: write
       pull-requests: write
       actions: read
+      checks: read
+      statuses: read
     with:
       unconditional: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,6 @@ on:
     branches:
       - master
   workflow_dispatch:
-    inputs:
-      workflow:
-        required: true
-        type: choice
-        options:
-          - lint-and-test
-          - release
-        description: Choose the workflow to run
-        default: lint-and-test
 defaults:
   run:
     shell: bash -euo pipefail {0}
@@ -26,46 +17,29 @@ jobs:
     if: >
       github.event_name == 'push'
       || github.event_name == 'pull_request'
-      || (github.event_name == 'workflow_dispatch' && inputs.workflow == 'lint-and-test')
+      || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
-    uses: dceoy/gha-for-devops/.github/workflows/python-package-lint-and-scan.yml@main
+    uses: dceoy/gha-for-devops/.github/workflows/python-package-lint-and-scan.yml@main  # zizmor: ignore[unpinned-uses]
     with:
       package-path: .
   python-test:
     if: >
       github.event_name == 'push'
       || github.event_name == 'pull_request'
-      || (github.event_name == 'workflow_dispatch' && inputs.workflow == 'lint-and-test')
+      || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
-    uses: dceoy/gha-for-devops/.github/workflows/python-package-test.yml@main
+    uses: dceoy/gha-for-devops/.github/workflows/python-package-test.yml@main   # zizmor: ignore[unpinned-uses]
     with:
       package-path: .
-  python-package-release:
-    if: >
-      github.event_name == 'push'
-      || (
-        github.event_name == 'workflow_dispatch'
-        && (inputs.workflow == 'release' || inputs.workflow == 'lint-and-test')
-      )
-    permissions:
-      contents: write
-      id-token: write
-    uses: dceoy/gha-for-devops/.github/workflows/python-package-release-on-pypi-and-github.yml@main
-    with:
-      package-path: .
-      create-releases: ${{ github.event_name == 'workflow_dispatch' && inputs.workflow == 'release' }}
-    secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   dependabot-auto-merge:
     if: >
       github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
     needs:
       - python-lint-and-scan
       - python-test
-    uses: dceoy/gha-for-devops/.github/workflows/dependabot-auto-merge.yml@main
+    uses: dceoy/gha-for-devops/.github/workflows/dependabot-auto-merge.yml@main   # zizmor: ignore[unpinned-uses]
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+---
+name: Release
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+    working-directory: .
+jobs:
+  build-and-release:
+    permissions:
+      contents: write
+      id-token: write
+    uses: dceoy/gha-for-devops/.github/workflows/python-package-release-on-pypi-and-github.yml@main  # zizmor: ignore[unpinned-uses]
+    with:
+      package-path: .
+      create-github-release: true
+      publish-to-pypi: false
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  publish-to-pypi:
+    name: Publish the Python 🐍 distribution 📦 to PyPI
+    if: >
+      startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build-and-release
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/${{ needs.build-and-release.outputs.project-name }}
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: ${{ needs.build-and-release.outputs.distribution-artifact-name }}
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1
+        with:
+          verbose: true

--- a/uv.lock
+++ b/uv.lock
@@ -301,7 +301,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7,<8" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
-    { name = "ruff", specifier = ">=0.14.0,<0.16.0" },
+    { name = "ruff", specifier = ">=0.14.0,<0.17.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -174,11 +174,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.1"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Move package release out of `ci.yml` into a dedicated `release.yml` workflow with manual dispatch
- Publish to PyPI only from tags via trusted publishing after the build/release job
- Grant `checks` and `statuses` read permissions to dependabot auto-merge

## Test plan
- [ ] Confirm CI still runs on push/PR/`workflow_dispatch`
- [ ] Dry-run `Release` via `workflow_dispatch` and verify GitHub release creation
- [ ] Verify PyPI publish job is skipped without a tag and runs when triggered from a tag


Made with [Cursor](https://cursor.com)